### PR TITLE
Allow characters if they have been explicit replacement chars

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -56,7 +56,7 @@
 
     for (var i = 0, length = string.length; i < length; i++) {
       var char = string[i]
-
+      var replacementChar = opts.charmap[char]
       if (!lengths.some(function (len) {
         var str = string.substr(i, len)
 
@@ -68,8 +68,8 @@
           return false
         }
       })) {
-        if (typeof opts.charmap[char] === 'string') {
-          char = opts.charmap[char]
+        if (typeof replacementChar === 'string') {
+          char = replacementChar
           code = char.charCodeAt(0)
         } else {
           code = string.charCodeAt(i)
@@ -86,7 +86,9 @@
         }
       }
 
-      char = char.replace(/[^\w\s\-\.\_~]/g, '') // allowed
+      if (typeof replacementChar !== 'string') {
+        char = char.replace(/[^\w\s\-\.\_~]/g, '') // allowed
+      }
 
       if (opts.remove) {
         char = char.replace(opts.remove, '') // add flavour

--- a/test.js
+++ b/test.js
@@ -38,6 +38,14 @@ describe('slug', function () {
     }
   })
 
+  it('should leave non-allowed characters if they are in the charmap', function () {
+    var char_map = {
+      ']': '['
+    }
+
+    slug('foo] bar baz', {charmap: char_map}).should.eql('foo[-bar-baz')
+  })
+
   it('should replace latin chars', function () {
     var char_map = {
       'À': 'A', 'Á': 'A', 'Â': 'A', 'Ã': 'A', 'Ä': 'A', 'Å': 'A', 'Æ': 'AE',
@@ -284,15 +292,6 @@ describe('slug', function () {
     slug("It's Your Journey We Guide You Through.", {
       limit: 5
     }).should.eql('its-your-journey-we-guide')
-  })
-
-  it('should remove disallowed characters even if they are in the char map', function () {
-    var charMap = {
-      '©': '(c)'
-    }
-    slug('mollusc ©', {
-      charmap: charMap
-    }).should.eql('mollusc-c')
   })
 
   it('should allow you to replace valid characters with an empty string', function () {


### PR DESCRIPTION
@Zertz 

This one may be a bit controversial
I believe that any replacement character in the charmap should not be stripped out

For example, 
The default charmap in this module has the following replacement `'©': '(c)'`
So `©` is replaced with `(c)` 
This is then replaced with `c` due to this line `char = char.replace(/[^\w\s\-\.\_~]/g, '')`

So arguably, the replacement should either be  `'©': 'c'` or the module should respect replacements
I have erred on the side of the module respecting replacements as this fits my current use case

Keen to hear people thoughts on this
