### PR TITLE
Stricter checking of charmap replacement

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -68,7 +68,7 @@
           return false
         }
       })) {
-        if (opts.charmap[char] !== undefined) {
+        if (typeof opts.charmap[char] === 'string') {
           char = opts.charmap[char]
           code = char.charCodeAt(0)
         } else {

--- a/slug.js
+++ b/slug.js
@@ -68,7 +68,7 @@
           return false
         }
       })) {
-        if (opts.charmap[char]) {
+        if (opts.charmap[char] !== undefined) {
           char = opts.charmap[char]
           code = char.charCodeAt(0)
         } else {

--- a/test.js
+++ b/test.js
@@ -294,4 +294,13 @@ describe('slug', function () {
       charmap: charMap
     }).should.eql('mollusc-c')
   })
+
+  it('should allow you to replace valid characters with an empty string', function () {
+    var charMap = {
+      '.': ''
+    }
+    slug('my.string', {
+      charmap: charMap
+    }).should.eql('mystring')
+  })
 })


### PR DESCRIPTION
@Zertz 

This fixes a bug where you cannot replace a char with an empty string
The code was currently checking for a falsey value which `''` falls into
